### PR TITLE
Add --lang option to choose English or Chinese output

### DIFF
--- a/src/video_autocut/app/cli.py
+++ b/src/video_autocut/app/cli.py
@@ -80,6 +80,13 @@ class OutputFormat(str, Enum):
     txt = "txt"
 
 
+class Language(str, Enum):
+    """Supported output languages."""
+
+    en = "en"
+    zh = "zh"
+
+
 def _validate_video_path(path: Path) -> Path:
     """Ensure the file exists and has a supported video extension."""
     if not path.exists():
@@ -191,6 +198,11 @@ def generate(
         "--strategy",
         help="Frame extraction strategy: uniform, scene_change, keyframe.",
     ),
+    lang: Language = typer.Option(
+        Language.en,
+        "--lang", "-l",
+        help="Output language: en (English), zh (Chinese).",
+    ),
 ) -> None:
     """Analyse a video and generate a shooting script.
 
@@ -212,6 +224,7 @@ def generate(
 
     console.print(f"[bold]Video:[/bold]  {video}")
     console.print(f"[bold]Type:[/bold]   {script_type}")
+    console.print(f"[bold]Lang:[/bold]   {lang.value}")
     if duration > 0:
         console.print(f"[bold]Duration:[/bold] {duration:.0f}s")
     console.print(f"[dim]Run ID:[/dim]  {run_id}")
@@ -231,6 +244,7 @@ def generate(
             fmt=fmt,
             max_frames=max_frames,
             strategy=strategy,
+            lang=lang.value,
             settings=settings,
         )
     )
@@ -248,6 +262,7 @@ async def _run_generate(
     fmt: OutputFormat,
     max_frames: int,
     strategy: str,
+    lang: str,
     settings,
 ) -> None:
     """Async implementation of the generate pipeline."""
@@ -261,6 +276,7 @@ async def _run_generate(
                 strategy=strategy,
                 max_frames=max_frames,
                 user_prompt=prompt,
+                lang=lang,
                 settings=settings,
             )
     except (VideoValidationError, VideoProbeError) as exc:
@@ -309,6 +325,7 @@ async def _run_generate(
                 target_audience=audience,
                 style=style,
                 emphasis=prompt,
+                lang=lang,
                 settings=settings,
             )
     except asyncio.TimeoutError as exc:

--- a/src/video_autocut/tools/script_generator.py
+++ b/src/video_autocut/tools/script_generator.py
@@ -168,6 +168,20 @@ def _build_user_prompt(
 # ---------------------------------------------------------------------------
 
 
+_LANG_INSTRUCTIONS: dict[str, str] = {
+    "en": "You MUST write all output text in English.",
+    "zh": "你必须用中文撰写所有输出内容。",
+}
+
+
+def _localized_prompt(prompt: str, lang: str) -> str:
+    """Append a language instruction to *prompt* if applicable."""
+    instruction = _LANG_INSTRUCTIONS.get(lang, "")
+    if instruction:
+        return f"{prompt}\n\n{instruction}"
+    return prompt
+
+
 async def generate_script(
     analysis: VideoAnalysisResult,
     *,
@@ -176,6 +190,7 @@ async def generate_script(
     target_audience: str = "",
     style: str = "",
     emphasis: str = "",
+    lang: str = "en",
     settings: Settings | None = None,
 ) -> ScriptGenerationResult:
     """Generate a shooting script from a video analysis result.
@@ -191,6 +206,7 @@ async def generate_script(
         style: Visual/editorial style guidance (e.g. ``"minimalist"``).
         emphasis: Optional user note to steer the LLM
             (e.g. ``"focus on the cooking scenes"``).
+        lang: Output language code (``"en"`` or ``"zh"``).
         settings: Explicit settings.  Defaults to :func:`get_settings`.
 
     Returns:
@@ -207,7 +223,7 @@ async def generate_script(
     if ":" in model_name:
         model_name = model_name.split(":", 1)[1]
 
-    system_prompt = _build_system_prompt(script_type)
+    system_prompt = _localized_prompt(_build_system_prompt(script_type), lang)
     user_prompt = _build_user_prompt(
         analysis, script_type, target_duration,
         target_audience, style, emphasis,

--- a/src/video_autocut/tools/video_analysis.py
+++ b/src/video_autocut/tools/video_analysis.py
@@ -73,6 +73,11 @@ For each frame, identify:
 
 Be precise and objective.  Describe what you see, not what you infer."""
 
+_LANG_INSTRUCTIONS: dict[str, str] = {
+    "en": "You MUST write all output text in English.",
+    "zh": "你必须用中文撰写所有输出内容。",
+}
+
 SYNTHESIS_PROMPT = """\
 You are a professional video analyst.  Synthesize the per-frame analyses \
 below into a coherent video content summary.
@@ -94,12 +99,21 @@ generation."""
 # ---------------------------------------------------------------------------
 
 
+def _localized_prompt(prompt: str, lang: str) -> str:
+    """Append a language instruction to *prompt* if *lang* is not English."""
+    instruction = _LANG_INSTRUCTIONS.get(lang, "")
+    if instruction:
+        return f"{prompt}\n\n{instruction}"
+    return prompt
+
+
 async def analyze_video(
     video_path: str | Path,
     *,
     strategy: str = "uniform",
     max_frames: int = 10,
     user_prompt: str = "",
+    lang: str = "en",
     settings: Settings | None = None,
 ) -> VideoAnalysisResult:
     """Analyze a video end-to-end: extract → analyze → synthesize.
@@ -115,6 +129,7 @@ async def analyze_video(
         max_frames: Maximum number of frames to extract and analyze.
         user_prompt: Optional context from the user that is included in
             every LLM prompt (e.g. "focus on the outdoor scenes").
+        lang: Output language code (``"en"`` or ``"zh"``).
         settings: Explicit settings instance.  When *None* the cached
             singleton from :func:`get_settings` is used.
 
@@ -165,6 +180,7 @@ async def analyze_video(
                 video_name=video_name,
                 model_name=model_name,
                 user_prompt=user_prompt,
+                lang=lang,
                 settings=settings,
             )
             all_errors.extend(analysis_errors)
@@ -177,6 +193,7 @@ async def analyze_video(
                     video_name=video_name,
                     model_name=model_name,
                     user_prompt=user_prompt,
+                    lang=lang,
                     settings=settings,
                 )
                 content_summary = summary
@@ -221,6 +238,7 @@ async def _analyze_frames(
     video_name: str,
     model_name: str,
     user_prompt: str,
+    lang: str,
     settings: Settings,
 ) -> tuple[list[FrameAnalysis], list[PipelineError], list[TokenUsage]]:
     """Analyze extracted frames one-by-one with the vision LLM.
@@ -236,7 +254,7 @@ async def _analyze_frames(
     agent = create_structured_agent(
         FrameAnalysis,
         settings=settings,
-        system_prompt=FRAME_ANALYSIS_PROMPT,
+        system_prompt=_localized_prompt(FRAME_ANALYSIS_PROMPT, lang),
     )
 
     total = len(frames)
@@ -325,6 +343,7 @@ async def _synthesize_summary(
     video_name: str,
     model_name: str,
     user_prompt: str,
+    lang: str,
     settings: Settings,
 ) -> tuple[VideoContentSummary | None, TokenUsage | None, PipelineError | None]:
     """Aggregate per-frame analyses into a single content summary.
@@ -335,7 +354,7 @@ async def _synthesize_summary(
     agent = create_structured_agent(
         VideoContentSummary,
         settings=settings,
-        system_prompt=SYNTHESIS_PROMPT,
+        system_prompt=_localized_prompt(SYNTHESIS_PROMPT, lang),
     )
 
     # Serialize frame analyses to JSON for the text prompt.


### PR DESCRIPTION
Add a `--lang` / `-l` CLI option (en/zh) to the `generate` command. The language instruction is appended to every system prompt in the pipeline: frame analysis, content synthesis, and script generation.

Usage:
  video-autocut generate video.mp4 --lang zh
  video-autocut generate video.mp4 -l en  (default)

https://claude.ai/code/session_01WghFM7raaSBYMuY8wbxks3