### PR TITLE
Increase default request timeout from 60s to 120s

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,5 +28,5 @@ HUNYUAN_BASE_URL=https://api.hunyuan.cloud.tencent.com/v1
 # LOG_LEVEL=INFO
 # Max retries for LLM API calls, 0-10 (default: 3)
 # MAX_RETRIES=3
-# Timeout for LLM API calls in seconds, 5-600 (default: 60)
-# REQUEST_TIMEOUT_SECONDS=60
+# Timeout for LLM API calls in seconds, 5-600 (default: 120)
+# REQUEST_TIMEOUT_SECONDS=120

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ TEMP_FRAMES_DIR=.video_autocut/frames
 OUTPUT_DIR=.video_autocut/output
 LOG_LEVEL=INFO
 MAX_RETRIES=3
-REQUEST_TIMEOUT_SECONDS=60
+REQUEST_TIMEOUT_SECONDS=120
 ```
 
 ### Running

--- a/src/video_autocut/settings.py
+++ b/src/video_autocut/settings.py
@@ -79,7 +79,7 @@ class Settings(BaseSettings):
         description="Maximum retries for LLM API calls",
     )
     request_timeout_seconds: int = Field(
-        default=60,
+        default=120,
         ge=5,
         le=600,
         description="Timeout for a single LLM API call in seconds",

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -47,7 +47,7 @@ class TestDefaults:
         assert settings.output_dir == Path(".video_autocut/output")
         assert settings.log_level == "INFO"
         assert settings.max_retries == 3
-        assert settings.request_timeout_seconds == 60
+        assert settings.request_timeout_seconds == 120
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Structured output generation (especially Chinese with complex nested ShootingScript schema) frequently exceeds 60 seconds. Bump the default REQUEST_TIMEOUT_SECONDS to 120s. Users can still override via .env.

https://claude.ai/code/session_01WghFM7raaSBYMuY8wbxks3